### PR TITLE
Fixing the compilation error (gnu/intel); using stable eigen release

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,10 @@ First clone the repo with `git clone https://github.com/VladimirYugay/KinectFusi
 
 - Download header only Eigen library and put it into `libs` folder by runnning:\
   `cd KinectFusion/libs`\
-  `git clone https://gitlab.com/libeigen/eigen.git`
+  `git clone https://gitlab.com/libeigen/eigen.git`\
+  Use any stable release (e.g. 3.4.0) as the upstream currently requires specific compiler versions (newer than GCC 9.3.0 and Intel 2021.4.0.20210910)\
+  `cd eigen`\
+  `git checkout tags/3.4.0`
 
 #### Setup (Windows)
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -109,7 +109,7 @@ int main() {
               
               std::unordered_map<Vector3i, bool, matrix_hash<Vector3i>> visitedVoxels = volume.getVisitedVoxels();
 
-              for (auto&it = visitedVoxels.begin(); it != visitedVoxels.end(); it++)
+              for (auto it = visitedVoxels.begin(); it != visitedVoxels.end(); it++)
               {
                   //std::cout << it->first << std::endl;
                   Vector3i voxelCoords = it->first;


### PR DESCRIPTION
This pull request fixes a compilation error occurring on GCC 9.3.0 and Intel 2021.4.0.20210910. The problem has been encountered by others in  #6. Also, I have added in the README a recommendation to use a stable `eigen` release. Both my compilers are not able to compile the latest upstream `eigen` (weird but true! :)).

Error message on GNU:

```sh
[ 62%] Building CXX object CMakeFiles/kinect_fusion.dir/src/main.cpp.o
/home/KinectFusion/src/main.cpp: In function ‘int main()’:
/home/KinectFusion/src/main.cpp:112:50: error: cannot bind non-const lvalue reference of type ‘std::__detail::_Node_iterator<std::pair<const Eigen::Matrix<int, 3, 1>, bool>, false, true>&’ to an rvalue of type ‘std::unordered_map<Eigen::Matrix<int, 3, 1>, bool, matrix_hash<Eigen::Matrix<int, 3, 1> > >::iterator’ {aka ‘std::__detail::_Node_iterator<std::pair<const Eigen::Matrix<int, 3, 1>, bool>, false, true>’}
  112 |               for (auto &it = visitedVoxels.begin(); it != visitedVoxels.end(); it++)
      |                               ~~~~~~~~~~~~~~~~~~~^~
```

Thanks for the great work!